### PR TITLE
FIx for issue #188 (empy tooltips)

### DIFF
--- a/assets/js/default-calendar.js
+++ b/assets/js/default-calendar.js
@@ -363,7 +363,7 @@
 
 				eventBubbles.each( function( e, i ) {
 					$( i ).qtip( {
-						content : width < 60 ? $( cell ).find( 'ul.simcal-events' ) : $( i ).find( '> .simcal-tooltip-content' ),
+						content : width < 60 ? $( cell ).find( 'ul.simcal-events' ).clone() : $( i ).find( '> .simcal-tooltip-content' ).clone(),
 						position: {
 							my      : 'top center',
 							at      : 'bottom center',


### PR DESCRIPTION
Update for fixing the empty-tooltip-after-resize bug (issue #188). Added .clone() in tooltip content prevents qtip from removing the tooltip content from its original location in DOM. This fix is also mentioned here: http://qtip2.com/options#content.text